### PR TITLE
Move build step and database dump from travis.yml to bash script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: java
 jdk:
-- openjdk8
+  - openjdk8
 
 install: skip
 
 before_script:
   - sudo service mysql stop
-  - docker-compose -f core/docker-compose.yml up -d
   - gem install asciidoctor-pdf --pre
-  
+
 script:
-- mvn package -DskipTests
-- mysqldump --protocol tcp -h localhost -u isf -pisf123 --compatible=mysql40 oh > database.sql
-- "./build_poh.sh"
+  - "./build_poh.sh"
 
 deploy:
   provider: releases

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This is the *root* project of the [Open Hospital][openhospital] code base.
 ## How to create Open Hospital portable
 
 To create the Open Hospital portable distributions,
-make sure to have installed the following dependencies on a Linux machine: 
-JDK 6+, Maven, asciidoctor-pdf, docker-compose, MySQL client.  
+make sure to have installed the following dependencies on a Linux machine:
+_JDK 6+, Maven, asciidoctor-pdf, docker-compose, MySQL client, zip._
+ 
 Then follow these simple steps:
 
  1. Clone this repository and initialize the submodules:
@@ -16,6 +17,7 @@ Then follow these simple steps:
 
  2. Run the script that compiles the projects *core* and *gui*, and assembles the portable distributions:
 
+        cd openhospital
         ./build_poh.sh
 
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,16 @@ This is the *root* project of the [Open Hospital][openhospital] code base.
 
 ## How to create Open Hospital portable
 
-These are the steps to create the portable distributions of Open Hospital:
+To create the Open Hospital portable distributions,
+make sure to have installed the following dependencies on a Linux machine: 
+JDK 6+, Maven, asciidoctor-pdf, docker-compose, MySQL client.  
+Then follow these simple steps:
 
  1. Clone this repository and initialize the submodules:
 
         git clone --recurse-submodules https://github.com/informatici/openhospital
 
- 2. Compile the projects *core* and *gui* by issuing:
-
-        mvn package -DskipTests
-
- 3. Assemble the portable distributions for Windows and for Linux:
+ 2. Run the script that compiles the projects *core* and *gui*, and assembles the portable distributions:
 
         ./build_poh.sh
 

--- a/build_poh.sh
+++ b/build_poh.sh
@@ -25,8 +25,8 @@ show_doc () {
 for arg in $requirements
 do
     if ! command_exists $arg; then 
-	show_req $arg
-fi
+		show_req $arg
+	fi
 done
 
 set -e
@@ -42,6 +42,13 @@ major=$(grep VER_MAJOR $version_file | cut -d"=" -f2)
 minor=$(grep VER_MINOR $version_file | cut -d"=" -f2)
 release=$(grep VER_RELEASE $version_file | cut -d"=" -f2)
 version="$major.$minor.$release"
+
+# compile core and gui projects
+docker-compose -f core/docker-compose.yml up -d
+mvn package
+
+# dump the database to a SQL script
+mysqldump --protocol tcp -h localhost -u isf -pisf123 --compatible=mysql40 oh > database.sql
 
 # convert documentation
 if command_exists asciidoctor-pdf; then

--- a/build_poh.sh
+++ b/build_poh.sh
@@ -15,15 +15,22 @@ minor=$(grep VER_MINOR $version_file | cut -d"=" -f2)
 release=$(grep VER_RELEASE $version_file | cut -d"=" -f2)
 version="$major.$minor.$release"
 
-# converting documentation
+# compile core and gui projects
+docker-compose -f core/docker-compose.yml up -d
+mvn package
+
+# dump the database to a SQL script
+mysqldump --protocol tcp -h localhost -u isf -pisf123 --compatible=mysql40 oh > database.sql
+
+# convert documentation
 asciidoctor-pdf ./doc/doc_admin/AdminManual.adoc -o AdminManual.pdf
 asciidoctor-pdf ./doc/doc_user/UserManual.adoc -o UserManual.pdf
 
-# estracting changelogs
+# extract changelogs
 cp core/doc/`ls core/doc/ -r | head -n 1` core_`ls core/doc/ -r | head -n 1`
 cp gui/doc/`ls gui/doc/ -r | head -n 1` gui_`ls gui/doc/ -r | head -n 1`
 
-# assembling windows portable
+# assemble OH Windows portable
 mkdir -p ./poh-win32-$poh_win32_version-core-$version/oh/doc
 cp -rf ./poh-bundle-win/* ./poh-win32-$poh_win32_version-core-$version
 cp -rf ./gui/target/OpenHospital20/* ./poh-win32-$poh_win32_version-core-$version/oh
@@ -31,7 +38,7 @@ cp *.sql ./poh-win32-$poh_win32_version-core-$version
 cp *.pdf ./poh-win32-$poh_win32_version-core-$version/oh/doc
 cp *.txt ./poh-win32-$poh_win32_version-core-$version/oh/doc
 
-# assembling linux portable 
+# assemble OH Linux portable
 mkdir -p ./poh-linux-$poh_linux_version-core-$version/oh/doc
 cp -rf ./poh-bundle-linux/* ./poh-linux-$poh_linux_version-core-$version
 cp -rf ./gui/target/OpenHospital20/* ./poh-linux-$poh_linux_version-core-$version/oh
@@ -39,11 +46,14 @@ cp *.sql ./poh-linux-$poh_linux_version-core-$version
 cp *.pdf ./poh-linux-$poh_linux_version-core-$version/oh/doc
 cp *.txt ./poh-linux-$poh_linux_version-core-$version/oh/doc
 
-# packaging
+# package
 zip -r poh-win32-$poh_win32_version-core-$version.zip poh-win32-$poh_win32_version-core-$version
 tar -cvzf poh-linux-$poh_linux_version-core-$version.tar.gz poh-linux-$poh_linux_version-core-$version
 
 # check
 ls
+
+# cleanup
+docker-compose -f core/docker-compose.yml down
 
 echo "Portable distributions of Open Hospital created successfully."

--- a/build_poh.sh
+++ b/build_poh.sh
@@ -25,8 +25,8 @@ show_doc () {
 for arg in $requirements
 do
     if ! command_exists $arg; then 
-	show_req $arg
-fi
+        show_req $arg
+    fi
 done
 
 set -e

--- a/build_poh.sh
+++ b/build_poh.sh
@@ -1,6 +1,34 @@
 #!/bin/bash
 # This script assembles the portable distributions of Open Hospital.
 
+command_exists () {
+    type "$1" &> /dev/null ;
+}
+
+requirements="java mvn docker-compose mysql zip"
+show_req () {
+	echo `tput smul`$1' not found'`tput sgr0`
+	echo ''
+	echo 'Make sure to have installed the following dependencies on a Linux machine:'
+	echo 'JDK 6+, Maven, asciidoctor-pdf, docker-compose, MySQL client, zip'
+	exit 1
+}
+
+show_doc () {
+	echo '*********************************'
+	echo 'asciidoctor-pdf is not installed.'
+	echo '*********************************'
+	echo '==> Admin Manual at https://github.com/informatici/openhospital-doc/blob/master/doc_admin/AdminManual.adoc'
+	echo '==> User Manual at https://github.com/informatici/openhospital-doc/blob/master/doc_user/UserManual.adoc'
+}
+
+for arg in $requirements
+do
+    if ! command_exists $arg; then 
+	show_req $arg
+fi
+done
+
 set -e
 
 # set the portable distribution version
@@ -15,18 +43,13 @@ minor=$(grep VER_MINOR $version_file | cut -d"=" -f2)
 release=$(grep VER_RELEASE $version_file | cut -d"=" -f2)
 version="$major.$minor.$release"
 
-# compile core and gui projects
-docker-compose -f core/docker-compose.yml up -d
-mvn package
-
-# dump the database to a SQL script
-mysqldump --protocol tcp -h localhost -u isf -pisf123 --compatible=mysql40 oh > database.sql
-
 # convert documentation
-asciidoctor-pdf ./doc/doc_admin/AdminManual.adoc -o AdminManual.pdf
-asciidoctor-pdf ./doc/doc_user/UserManual.adoc -o UserManual.pdf
+if command_exists asciidoctor-pdf; then
+	asciidoctor-pdf ./doc/doc_admin/AdminManual.adoc -o AdminManual.pdf
+	asciidoctor-pdf ./doc/doc_user/UserManual.adoc -o UserManual.pdf
+fi
 
-# extract changelogs
+# estracting changelogs
 cp core/doc/`ls core/doc/ -r | head -n 1` core_`ls core/doc/ -r | head -n 1`
 cp gui/doc/`ls gui/doc/ -r | head -n 1` gui_`ls gui/doc/ -r | head -n 1`
 
@@ -35,7 +58,6 @@ mkdir -p ./poh-win32-$poh_win32_version-core-$version/oh/doc
 cp -rf ./poh-bundle-win/* ./poh-win32-$poh_win32_version-core-$version
 cp -rf ./gui/target/OpenHospital20/* ./poh-win32-$poh_win32_version-core-$version/oh
 cp *.sql ./poh-win32-$poh_win32_version-core-$version
-cp *.pdf ./poh-win32-$poh_win32_version-core-$version/oh/doc
 cp *.txt ./poh-win32-$poh_win32_version-core-$version/oh/doc
 
 # assemble OH Linux portable
@@ -43,17 +65,20 @@ mkdir -p ./poh-linux-$poh_linux_version-core-$version/oh/doc
 cp -rf ./poh-bundle-linux/* ./poh-linux-$poh_linux_version-core-$version
 cp -rf ./gui/target/OpenHospital20/* ./poh-linux-$poh_linux_version-core-$version/oh
 cp *.sql ./poh-linux-$poh_linux_version-core-$version
-cp *.pdf ./poh-linux-$poh_linux_version-core-$version/oh/doc
 cp *.txt ./poh-linux-$poh_linux_version-core-$version/oh/doc
 
-# package
+# check documentation
+if command_exists asciidoctor-pdf; then
+	cp *.pdf ./poh-win32-$poh_win32_version-core-$version/oh/doc
+	cp *.pdf ./poh-linux-$poh_linux_version-core-$version/oh/doc
+else show_doc;
+fi
+
+# packaging
 zip -r poh-win32-$poh_win32_version-core-$version.zip poh-win32-$poh_win32_version-core-$version
 tar -cvzf poh-linux-$poh_linux_version-core-$version.tar.gz poh-linux-$poh_linux_version-core-$version
 
 # check
 ls
-
-# cleanup
-docker-compose -f core/docker-compose.yml down
 
 echo "Portable distributions of Open Hospital created successfully."

--- a/build_poh.sh
+++ b/build_poh.sh
@@ -25,13 +25,8 @@ show_doc () {
 for arg in $requirements
 do
     if ! command_exists $arg; then 
-<<<<<<< HEAD
-		show_req $arg
-	fi
-=======
         show_req $arg
     fi
->>>>>>> 2b53807f4d0537b440f446f0f8152958c4c34d82
 done
 
 set -e


### PR DESCRIPTION
The goal is to be able to create the distribution with one script.

TODO: 
 - ~add build requirements (docker-compose, mysqldump, maven) to readme~