### PR TITLE
Update the default JRE's to 11

### DIFF
--- a/build_poh.sh
+++ b/build_poh.sh
@@ -97,7 +97,7 @@ cp CHANGELOG $FULL_DIR
 
 echo 'Assemble OH Windows portable...'
 cp -rf ./poh-bundle-win/* $WIN_DIR
-curl -L https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jre_x86-32_windows_hotspot_8u252b09.zip > win-java.zip
+curl -L https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.7_10.zip > win-java.zip
 unzip win-java.zip -d $WIN_DIR
 rm win-java.zip
 cp -rf ./gui/target/OpenHospital20/* $WIN_DIR/oh
@@ -111,7 +111,7 @@ cp CHANGELOG $WIN_DIR
 
 echo 'Assemble OH Linux x32 portable...'
 cp -rf ./poh-bundle-linux-x32/* $LINUX32_DIR
-curl -L https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jre8.0.252-linux_i686.tar.gz | tar xz -C $LINUX32_DIR
+curl -L https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-jre11.0.7-linux_i686.tar.gz | tar xz -C $LINUX32_DIR
 cp -rf ./gui/target/OpenHospital20/* $LINUX32_DIR/oh
 rm $LINUX32_DIR/oh/generate_changelog.sh || true
 cp *.sql $LINUX32_DIR
@@ -123,7 +123,7 @@ cp CHANGELOG $LINUX32_DIR
 
 echo 'Assemble OH Linux x64 portable...'
 cp -rf ./poh-bundle-linux-x64/* $LINUX64_DIR
-curl -L https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_x64_linux_hotspot_8u252b09.tar.gz | tar xz -C $LINUX64_DIR
+curl -L https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.7_10.tar.gz | tar xz -C $LINUX64_DIR
 cp -rf ./gui/target/OpenHospital20/* $LINUX64_DIR/oh
 rm $LINUX64_DIR/oh/generate_changelog.sh || true
 cp *.sql $LINUX64_DIR

--- a/poh-bundle-linux-x32/oh.sh
+++ b/poh-bundle-linux-x32/oh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 MYSQL_DIR="mysql-5.0.51a-linux-i686"
-JAVA_DIR="zulu8.46.0.19-ca-jre8.0.252-linux_i686"
+JAVA_DIR="zulu11.39.15-ca-jre11.0.7-linux_i686"
 OH_DIR="oh"
 DICOM_DEFAULT_SIZE="4M"
 

--- a/poh-bundle-linux-x64/oh.sh
+++ b/poh-bundle-linux-x64/oh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 MYSQL_DIR="mysql-5.0.51a-linux-i686"
-JAVA_DIR="jdk8u252-b09-jre"
+JAVA_DIR="jdk-11.0.7+10-jre"
 OH_DIR="oh"
 DICOM_DEFAULT_SIZE="4M"
 

--- a/poh-bundle-win/oh.bat
+++ b/poh-bundle-win/oh.bat
@@ -73,6 +73,6 @@ set CLASSPATH=%CLASSPATH%;%OH_BUNDLE%
 set CLASSPATH=%CLASSPATH%;%OH_REPORT%
 
 cd /d %OH_PATH%oh\
-%OH_PATH%jdk8u252-b09-jre\bin\java.exe -Dlog4j.configuration=%OH_PATH%oh/rsc/log4j.properties -showversion -Dsun.java2d.dpiaware=false -Djava.library.path=%OH_PATH%oh\lib\native\Windows -cp %CLASSPATH% org.isf.menu.gui.Menu
+%OH_PATH%jdk-11.0.7+10-jre\bin\java.exe -Dlog4j.configuration=%OH_PATH%oh/rsc/log4j.properties -showversion -Dsun.java2d.dpiaware=false -Djava.library.path=%OH_PATH%oh\lib\native\Windows -cp %CLASSPATH% org.isf.menu.gui.Menu
 start /b %OH_PATH%mysql\bin\mysqladmin --user=root --password= --port=%freePort% shutdown
 exit


### PR DESCRIPTION
follow-up to #121

This updates the Java Runtime Environment for the default bundles to Java 11

The language level for the java code stays on 8, so the software can be compiled and run using Java 8, too.