### PR TITLE
Use JRE 11

### DIFF
--- a/build_poh.sh
+++ b/build_poh.sh
@@ -106,9 +106,9 @@ mkdir -p $DOWNLOAD_DIR
 download_jre_mysql() {
     pushd $DOWNLOAD_DIR
     URL_LIST=(
-        "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jre_x86-32_windows_hotspot_8u252b09.zip"
-        "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09/OpenJDK8U-jre_x64_linux_hotspot_8u252b09.tar.gz"
-        "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jre8.0.252-linux_i686.tar.gz"
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10.2/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.7_10.zip"
+        "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.7_10.tar.gz"
+        "https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-jre11.0.7-linux_i686.tar.gz"
         "https://downloads.mysql.com/archives/get/p/23/file/mysql-5.7.30-win32.zip"
         "https://downloads.mysql.com/archives/get/p/23/file/mysql-5.7.30-linux-glibc2.12-x86_64.tar.gz"
         "https://downloads.mysql.com/archives/get/p/23/file/mysql-5.7.30-linux-glibc2.12-i686.tar.gz")
@@ -129,7 +129,7 @@ download_jre_mysql
 
 echo 'Assemble OH Windows portable...'
 cp -rf ./poh-bundle-win/* $WIN_DIR
-unzip $DOWNLOAD_DIR/OpenJDK8U-jre_x86-32_windows_hotspot_8u252b09.zip -d $WIN_DIR
+unzip $DOWNLOAD_DIR/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.7_10.zip -d $WIN_DIR
 unzip $DOWNLOAD_DIR/mysql-5.7.30-win32.zip -d $WIN_DIR -x "*/lib/*"
 cp -rf ./gui/target/OpenHospital20/* $WIN_DIR/oh
 rm -rf $WIN_DIR/oh/generate_changelog.sh
@@ -142,7 +142,7 @@ cp CHANGELOG $WIN_DIR
 
 echo 'Assemble OH Linux x32 portable...'
 cp -rf ./poh-bundle-linux-x32/* $LINUX32_DIR
-tar xz -C $LINUX32_DIR -f $DOWNLOAD_DIR/zulu8.46.0.19-ca-jre8.0.252-linux_i686.tar.gz
+tar xz -C $LINUX32_DIR -f $DOWNLOAD_DIR/zulu11.39.15-ca-jre11.0.7-linux_i686.tar.gz
 tar xz -C $LINUX32_DIR -f $DOWNLOAD_DIR/mysql-5.7.30-linux-glibc2.12-i686.tar.gz --exclude="*/lib/*"
 cp -rf ./gui/target/OpenHospital20/* $LINUX32_DIR/oh
 rm -rf $LINUX32_DIR/oh/generate_changelog.sh
@@ -155,7 +155,7 @@ cp CHANGELOG $LINUX32_DIR
 
 echo 'Assemble OH Linux x64 portable...'
 cp -rf ./poh-bundle-linux-x64/* $LINUX64_DIR
-tar xz -C $LINUX64_DIR -f $DOWNLOAD_DIR/OpenJDK8U-jre_x64_linux_hotspot_8u252b09.tar.gz
+tar xz -C $LINUX64_DIR -f $DOWNLOAD_DIR/OpenJDK11U-jre_x64_linux_hotspot_11.0.7_10.tar.gz
 tar xz -C $LINUX64_DIR -f $DOWNLOAD_DIR/mysql-5.7.30-linux-glibc2.12-x86_64.tar.gz --exclude="*/lib/*"
 cp -rf ./gui/target/OpenHospital20/* $LINUX64_DIR/oh
 rm -rf $LINUX64_DIR/oh/generate_changelog.sh

--- a/poh-bundle-linux-x32/oh.sh
+++ b/poh-bundle-linux-x32/oh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 MYSQL_DIR="mysql-5.7.30-linux-glibc2.12-i686"
-JAVA_DIR="jdk8u252-b09-jre"
+JAVA_DIR="zulu11.39.15-ca-jre11.0.7-linux_i686"
 OH_DIR="oh"
 DICOM_DEFAULT_SIZE="4M"
 

--- a/poh-bundle-linux-x64/oh.sh
+++ b/poh-bundle-linux-x64/oh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 MYSQL_DIR="mysql-5.7.30-linux-glibc2.12-x86_64"
-JAVA_DIR="jdk8u252-b09-jre"
+JAVA_DIR="jdk-11.0.7+10-jre"
 OH_DIR="oh"
 DICOM_DEFAULT_SIZE="4M"
 

--- a/poh-bundle-win/oh.bat
+++ b/poh-bundle-win/oh.bat
@@ -77,7 +77,7 @@ set CLASSPATH=%CLASSPATH%;%OH_BUNDLE%
 set CLASSPATH=%CLASSPATH%;%OH_REPORT%
 
 cd /d %OH_PATH%oh\
-%OH_PATH%jdk8u252-b09-jre\bin\java.exe -Dlog4j.configuration=%OH_PATH%oh/rsc/log4j.properties -showversion -Dsun.java2d.dpiaware=false -Djava.library.path=%OH_PATH%oh\lib\native\Windows -cp %CLASSPATH% org.isf.menu.gui.Menu
+%OH_PATH%jdk-11.0.7+10-jre\bin\java.exe -Dlog4j.configuration=%OH_PATH%oh/rsc/log4j.properties -showversion -Dsun.java2d.dpiaware=false -Djava.library.path=%OH_PATH%oh\lib\native\Windows -cp %CLASSPATH% org.isf.menu.gui.Menu
 start /b %OH_PATH%mysql-5.7.30-win32\bin\mysqladmin --user=root --password= --port=%freePort% shutdown
 exit
 


### PR DESCRIPTION
Use JRE 11 for the portable distribution instead of JRE 8.  
Bytecode compatibility remains the same (all code is compiled to v8).

Replace #125 