### PR TITLE
Chore: remove docker requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ our [Slack workspace][slack] or by subscribing to our [mailing list][ml].
 <details><summary>:construction_worker: :package:</summary>
 To create the Open Hospital packages,
 make sure to have installed the following dependencies on a Linux machine:
-JDK 8+, Maven, asciidoctor-pdf, docker, docker-compose, zip, GNU make.
+JDK 8+, Maven, asciidoctor-pdf, zip, GNU make.
 
 Then follow these simple steps:
 


### PR DESCRIPTION
Given change to remove `docker-compose` in last commit in OP-315, and there are no references to `docker` in the repo, removing `docker` from the README.md file.