### PR TITLE
Windows distro and DICOM / JAVA workaround update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ $(WIN32).zip: compile-all dw-all
 	cp -f ./openhospital-gui/oh.ico $(WIN32)/
 	rm -rf $(WIN32)/oh/generate_changelog.sh
 	cp OH-README.md OH-win-changelog.md LICENSE CHANGELOG $(WIN32)
+	# Workaround to force JAVA to 32bit to have DICOM working
+	sed -i '/script:JAVA_ARCH=32/s/^#//g' $(WIN32)/oh.ps1
 	cp *.pdf $(WIN32)/doc
 	zip -r $(WIN32).zip $(WIN32)
 
@@ -95,8 +97,6 @@ $(WIN64).zip: compile-all dw-all
 	rm -rf $(WIN64)/oh/generate_changelog.sh
 	cp OH-README.md OH-win-changelog.md LICENSE CHANGELOG $(WIN64)
 	cp *.pdf $(WIN64)/doc
-	# Workaround to disable DICOM on JAVA 64bit (uncomment configuration line)
-	sed -i '/script:DICOM_ENABLE=/s/^#//g' $(WIN64)/oh.ps1
 	zip -r $(WIN64).zip $(WIN64)
 
 $(LINUX32).tar.gz: compile-all dw-all
@@ -162,7 +162,7 @@ dw-all: dw-jre-all dw-mysql-all
 dw-jre-all: $(JRE_LINUX32) $(JRE_LINUX64) $(JRE_WIN32) $(JRE_WIN64)
 dw-mysql-all: $(MYSQL_LINUX32) $(MYSQL_LINUX64) $(MYSQL_WIN32) $(MYSQL_WIN64)
 $(JRE_LINUX32):
-	wget -q -nc https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jre11.0.10-linux_i686.tar.gz -O $(JRE_LINUX32)
+	wget -q -nc https://cdn.azul.com/zulu/bin/zulu11.50.19-ca-jre11.0.12-linux_i686.tar.gz -O $(JRE_LINUX32)
 $(JRE_LINUX64):
 	wget -q -nc https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.11_9.tar.gz -O $(JRE_LINUX64)
 $(JRE_WIN32):

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,16 @@ SHELL := /bin/bash
 .DELETE_ON_ERROR:		# delete the target if its recipe failed
 OH_VERSION ?= $(shell git describe --abbrev=0 --tags)
 CLIENT := OpenHospital-$(OH_VERSION)-multiarch-client
-WIN32 := OpenHospital-$(OH_VERSION)-win32-portable
+WIN32 := OpenHospital-$(OH_VERSION)-windows_i686-portable
+WIN64 := OpenHospital-$(OH_VERSION)-windows_x86_64-portable
 LINUX32 := OpenHospital-$(OH_VERSION)-linux_i686-portable
 LINUX64 := OpenHospital-$(OH_VERSION)-linux_x86_64-portable
-JRE_WIN := jre-win.zip
+JRE_WIN32 := jre-win32.zip
+JRE_WIN64 := jre-win64.zip
 JRE_LINUX32 := jre-linux32.tar.gz
 JRE_LINUX64 := jre-linux64.tar.gz
-MYSQL_WIN := mysql-win.zip
+MYSQL_WIN32 := mysql-win32.zip
+MYSQL_WIN64 := mysql-win64.zip
 MYSQL_LINUX32 := mysql-linux32.tar.gz
 MYSQL_LINUX64 := mysql-linux64.tar.gz
 MYSQL_VERSION := 10.2.40
@@ -29,8 +32,8 @@ all: compile-all dw-all release-files
 
 help:
 	@echo -e "Main make targets available:\n\tall (default), clean, clone-all, dw-all, compile-all, docs-all, dw-jre-all, dw-mysql-all, oh-admin-manual.pdf, oh-user-manual.pdf, core, gui, doc"
-	@echo -e "\t$(WIN32).zip, $(LINUX32).tar.gz, $(LINUX64).tar.gz, $(CLIENT).zip"
-	@echo -e "\t$(JRE_WIN), $(JRE_LINUX32), $(JRE_LINUX64), $(MYSQL_WIN), $(MYSQL_LINUX32), $(MYSQL_LINUX64)"
+	@echo -e "\t$(WIN32).zip, $(WIN64).zip $(LINUX32).tar.gz, $(LINUX64).tar.gz, $(CLIENT).zip"
+	@echo -e "\t$(JRE_WIN32), $(JRE_WIN64), $(JRE_LINUX32), $(JRE_LINUX64), $(MYSQL_WIN32), $(MYSQL_WIN64) $(MYSQL_LINUX32), $(MYSQL_LINUX64)"
 
 # Clean targets
 clean: clean-downloads
@@ -43,21 +46,22 @@ clean-downloads:
 compile-all: gui/target/OpenHospital20/bin/OH-gui.jar docs-all CHANGELOG 
 
 # Assemble targets
-release-files: $(CLIENT).zip $(WIN32).zip $(LINUX32).tar.gz $(LINUX64).tar.gz
+release-files: $(CLIENT).zip $(WIN32).zip $(WIN64).zip $(LINUX32).tar.gz $(LINUX64).tar.gz
 	echo "Checksum:" >> CHANGELOG.md
 	echo "\`\`\`" >> CHANGELOG.md
 	sha256sum $(CLIENT).zip >> CHANGELOG.md
 	sha256sum $(WIN32).zip >> CHANGELOG.md
+	sha256sum $(WIN64).zip >> CHANGELOG.md
 	sha256sum $(LINUX32).tar.gz >> CHANGELOG.md
 	sha256sum $(LINUX64).tar.gz >> CHANGELOG.md
 	echo "\`\`\`" >> CHANGELOG.md
 	mkdir -p release-files
-	mv $(CLIENT).zip $(WIN32).zip $(LINUX32).tar.gz $(LINUX64).tar.gz release-files/
+	mv $(CLIENT).zip $(WIN32).zip $(WIN64).zip $(LINUX32).tar.gz $(LINUX64).tar.gz release-files/
 	ls release-files
 
 $(CLIENT).zip: compile-all
-	mkdir -p $(CLIENT)/oh
 	mkdir -p $(CLIENT)/doc
+	mkdir -p $(CLIENT)/oh
 	cp -rf ./openhospital-gui/target/OpenHospital20/* $(CLIENT)/oh
 	cp -rf ./openhospital-core/sql $(CLIENT)/
 	cp -f ./openhospital-gui/oh.ico $(CLIENT)/
@@ -70,8 +74,8 @@ $(CLIENT).zip: compile-all
 $(WIN32).zip: compile-all dw-all
 	mkdir -p $(WIN32)/doc
 	cp -rf ./poh-bundle-win/* $(WIN32)
-	unzip $(JRE_WIN) -d $(WIN32)
-	unzip $(MYSQL_WIN) -d $(WIN32) -x "*/lib/*"
+	unzip $(JRE_WIN32) -d $(WIN32)
+	unzip $(MYSQL_WIN32) -d $(WIN32) -x "*/lib/*"
 	cp -rf ./openhospital-gui/target/OpenHospital20/* $(WIN32)/oh
 	cp -a ./openhospital-core/sql $(WIN32)/
 	cp -f ./openhospital-gui/oh.ico $(WIN32)/
@@ -79,6 +83,21 @@ $(WIN32).zip: compile-all dw-all
 	cp OH-README.md OH-win-changelog.md LICENSE CHANGELOG $(WIN32)
 	cp *.pdf $(WIN32)/doc
 	zip -r $(WIN32).zip $(WIN32)
+
+$(WIN64).zip: compile-all dw-all
+	mkdir -p $(WIN64)/doc
+	cp -rf ./poh-bundle-win/* $(WIN64)
+	unzip $(JRE_WIN64) -d $(WIN64)
+	unzip $(MYSQL_WIN64) -d $(WIN64) -x "*/lib/*"
+	cp -rf ./openhospital-gui/target/OpenHospital20/* $(WIN64)/oh
+	cp -a ./openhospital-core/sql $(WIN64)/
+	cp -f ./openhospital-gui/oh.ico $(WIN64)/
+	rm -rf $(WIN64)/oh/generate_changelog.sh
+	cp OH-README.md OH-win-changelog.md LICENSE CHANGELOG $(WIN64)
+	cp *.pdf $(WIN64)/doc
+	# Workaround to disable DICOM on JAVA 64bit (uncomment configuration line)
+	sed -i '/script:DICOM_ENABLE=/s/^#//g' $(WIN64)/oh.ps1
+	zip -r $(WIN64).zip $(WIN64)
 
 $(LINUX32).tar.gz: compile-all dw-all
 	mkdir -p $(LINUX32)/doc
@@ -140,18 +159,21 @@ CHANGELOG: core
 
 # Download JRE and MySQL
 dw-all: dw-jre-all dw-mysql-all
-dw-jre-all: $(JRE_LINUX32) $(JRE_LINUX64) $(JRE_WIN)
-dw-mysql-all: $(MYSQL_LINUX32) $(MYSQL_LINUX64) $(MYSQL_WIN)
+dw-jre-all: $(JRE_LINUX32) $(JRE_LINUX64) $(JRE_WIN32) $(JRE_WIN64)
+dw-mysql-all: $(MYSQL_LINUX32) $(MYSQL_LINUX64) $(MYSQL_WIN32) $(MYSQL_WIN64)
 $(JRE_LINUX32):
 	wget -q -nc https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jre11.0.10-linux_i686.tar.gz -O $(JRE_LINUX32)
 $(JRE_LINUX64):
 	wget -q -nc https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.11_9.tar.gz -O $(JRE_LINUX64)
-$(JRE_WIN):
-#	wget -q -nc https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.11_9.zip -O $(JRE_WIN)
-	wget -q -nc https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jre_x86-32_windows_hotspot_8u292b10.zip -O $(JRE_WIN)
+$(JRE_WIN32):
+	wget -q -nc https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jre_x86-32_windows_hotspot_8u292b10.zip -O $(JRE_WIN32)
+$(JRE_WIN64):
+	wget -q -nc https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.11_9.zip -O $(JRE_WIN64)
 $(MYSQL_LINUX32):
 	wget -q -nc https://downloads.mariadb.com/MariaDB/mariadb-$(MYSQL_VERSION)/bintar-linux-x86/mariadb-$(MYSQL_VERSION)-linux-i686.tar.gz -O $(MYSQL_LINUX32)
 $(MYSQL_LINUX64):
 	wget -q -nc https://downloads.mariadb.com/MariaDB/mariadb-$(MYSQL_VERSION)/bintar-linux-x86_64/mariadb-$(MYSQL_VERSION)-linux-x86_64.tar.gz -O $(MYSQL_LINUX64)
-$(MYSQL_WIN):
-	wget -q -nc https://downloads.mariadb.com/MariaDB/mariadb-$(MYSQL_VERSION)/winx64-packages/mariadb-$(MYSQL_VERSION)-winx64.zip -O $(MYSQL_WIN)
+$(MYSQL_WIN32):
+	wget -q -nc https://downloads.mariadb.org/f/mariadb-$(MYSQL_VERSION)/win32-packages/mariadb-$(MYSQL_VERSION)-win32.zip -O $(MYSQL_WIN32)
+$(MYSQL_WIN64):
+	wget -q -nc https://downloads.mariadb.com/MariaDB/mariadb-$(MYSQL_VERSION)/winx64-packages/mariadb-$(MYSQL_VERSION)-winx64.zip -O $(MYSQL_WIN64)

--- a/OH-README.md
+++ b/OH-README.md
@@ -189,7 +189,7 @@ MANUAL_CONFIG=off
 
 - (Windows only) enable / disable DICOM features
 ```
-# enable / disable DICOM (true|false)
+# enable / disable DICOM (on|off)
 #$script:DICOM_ENABLE="false"
 ```
 
@@ -253,7 +253,7 @@ sudo apt-get install libaio1
 **Windows**
 
 Dicom functionalities are only available on 32bit JAVA environment. If DICOM is needed, 32bit jre is mandatory.
-If you need DICOM on Windows 64 bit set **DICOM_ENABLE="true"** in the script.
+If you need DICOM on Windows 64 bit set **DICOM_ENABLE="on"** in the script.
 
 If you get this error:
 

--- a/poh-bundle-linux-x32/oh.sh
+++ b/poh-bundle-linux-x32/oh.sh
@@ -110,9 +110,9 @@ MYSQL_DIR="mariadb-$MYSQL_VERSION-linux-$ARCH"
 #JAVA_DIR="openlogic-openjdk-jre-8u262-b10-linux-64"
 
 ### JRE 11 - zulu distribution
-#JAVA_DISTRO="zulu11.45.27-ca-jre11.0.10-linux_x64"
+#JAVA_DISTRO="zulu11.50.19-ca-jre11.0.12-linux_x64"
 #JAVA_URL="https://cdn.azul.com/zulu/bin"
-#JAVA_DIR="zulu11.45.27-ca-jre11.0.9-linux_x64"
+#JAVA_DIR="zulu11.50.19-ca-jre11.0.12-linux_x64"
 
 ### JRE 11 - openjdk distribution
 JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9"
@@ -130,10 +130,10 @@ if [ $JAVA_ARCH = 32 ]; then
 	### JRE zulu distro
 	JAVA_URL="https://cdn.azul.com/zulu/bin/"
 	### JRE 8 32bit
-	#JAVA_DISTRO="zulu8.52.0.23-ca-jre8.0.282-linux_i686"
+	#JAVA_DISTRO="zulu8.56.0.21-ca-jre8.0.302-linux_i686"
 	### JRE 11 32bit
-	JAVA_DISTRO="zulu11.45.27-ca-jre11.0.10-linux_i686"
-
+	JAVA_DISTRO="zulu11.50.19-ca-jre11.0.12-linux_i686"
+	
 	JAVA_DIR=$JAVA_DISTRO
 fi
 

--- a/poh-bundle-linux-x64/oh.sh
+++ b/poh-bundle-linux-x64/oh.sh
@@ -110,9 +110,9 @@ MYSQL_DIR="mariadb-$MYSQL_VERSION-linux-$ARCH"
 #JAVA_DIR="openlogic-openjdk-jre-8u262-b10-linux-64"
 
 ### JRE 11 - zulu distribution
-#JAVA_DISTRO="zulu11.45.27-ca-jre11.0.10-linux_x64"
+#JAVA_DISTRO="zulu11.50.19-ca-jre11.0.12-linux_x64"
 #JAVA_URL="https://cdn.azul.com/zulu/bin"
-#JAVA_DIR="zulu11.45.27-ca-jre11.0.9-linux_x64"
+#JAVA_DIR="zulu11.50.19-ca-jre11.0.12-linux_x64"
 
 ### JRE 11 - openjdk distribution
 JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9"
@@ -130,10 +130,10 @@ if [ $JAVA_ARCH = 32 ]; then
 	### JRE zulu distro
 	JAVA_URL="https://cdn.azul.com/zulu/bin/"
 	### JRE 8 32bit
-	#JAVA_DISTRO="zulu8.52.0.23-ca-jre8.0.282-linux_i686"
+	#JAVA_DISTRO="zulu8.56.0.21-ca-jre8.0.302-linux_i686"
 	### JRE 11 32bit
-	JAVA_DISTRO="zulu11.45.27-ca-jre11.0.10-linux_i686"
-
+	JAVA_DISTRO="zulu11.50.19-ca-jre11.0.12-linux_i686"
+	
 	JAVA_DIR=$JAVA_DISTRO
 fi
 

--- a/poh-bundle-win/oh.ps1
+++ b/poh-bundle-win/oh.ps1
@@ -136,14 +136,14 @@ switch ( "$ARCH" ) {
 		Read-Host; exit 1
 	}
 
-#	# Workaround to force 32bit JAVA in order to have DICOM working
-#	if ( $DICOM_ENABLE -eq "on" ) {
-#		$script:JAVA_ARCH=32
-#	}
+	# Workaround to force 32bit JAVA in order to have DICOM working on 64bit arch
+	if ( $DICOM_ENABLE -eq "on" ) {
+		$script:JAVA_ARCH=32
+	}
 }
 	
 # Workaround to force 32bit JAVA in order to have DICOM working
-$script:JAVA_ARCH=32
+#$script:JAVA_ARCH=32
 
 ######## MySQL Software
 # MariaDB
@@ -168,15 +168,17 @@ $script:JAVA_DISTRO="OpenJDK11U-jre_x64_windows_hotspot_11.0.11_9"
 $script:JAVA_DIR="jdk-11.0.11+9-jre"
 
 ######## JAVA 32bit
-# DICOM workaround - force JAVA_ARCH to 32 bit
 if ( $JAVA_ARCH -eq "32" ) {
 	# Setting JRE 32 bit
 	### JRE 8 32bit - openjdk distribution
 	# https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jre_x86-32_windows_hotspot_8u292b10.zip
+	$script:JAVA_DISTRO="OpenJDK8U-jre_x86-32_windows_hotspot_8u292b10"
+	$script:JAVA_URL="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/"
+	$script:JAVA_DIR="jdk8u292-b10-jre"
 	### JRE 8 32bit - zulu distribution
-	$script:JAVA_DISTRO="zulu8.56.0.21-ca-jre8.0.302-win_i686"
-	$script:JAVA_URL="https://cdn.azul.com/zulu/bin/"
-	$script:JAVA_DIR="$JAVA_DISTRO"
+	#$script:JAVA_DISTRO="zulu8.56.0.21-ca-jre8.0.302-win_i686"
+	#$script:JAVA_URL="https://cdn.azul.com/zulu/bin/"
+	#$script:JAVA_DIR="$JAVA_DISTRO"
 
 	### JRE 11 32bit - zulu distribution
 	#$script:JAVA_DISTRO="zulu11.45.27-ca-jre11.0.10-win_i686"

--- a/poh-bundle-win/oh.ps1
+++ b/poh-bundle-win/oh.ps1
@@ -130,17 +130,20 @@ switch ( "$ARCH" ) {
 	"amd64" { $script:JAVA_ARCH=64; $script:MYSQL_ARCH="x64" }
 	"AMD64" { $script:JAVA_ARCH=64; $script:MYSQL_ARCH="x64" }
 	"x86_64" { $script:JAVA_ARCH=64; $script:MYSQL_ARCH="x64" }
-	("486","586","686","x86","i86pc") { $script:JAVA_ARCH=64; $script:MYSQL_ARCH=32 }
+	("486","586","686","x86","i86pc") { $script:JAVA_ARCH=32; $script:MYSQL_ARCH=32 }
 	default {
 		Write-Host "Unknown architecture: $ARCH. Exiting." -ForegroundColor Red
 		Read-Host; exit 1
 	}
 
-	# Workaround to force 32bit JAVA in order to have DICOM working
-	if ( $DICOM_ENABLE -eq "on" ) {
-		$script:JAVA_ARCH=32
-	}
+#	# Workaround to force 32bit JAVA in order to have DICOM working
+#	if ( $DICOM_ENABLE -eq "on" ) {
+#		$script:JAVA_ARCH=32
+#	}
 }
+	
+# Workaround to force 32bit JAVA in order to have DICOM working
+$script:JAVA_ARCH=32
 
 ######## MySQL Software
 # MariaDB

--- a/poh-bundle-win/oh.ps1
+++ b/poh-bundle-win/oh.ps1
@@ -77,8 +77,8 @@ $script:OH_MODE="PORTABLE"  # set functioning mode to PORTABLE | CLIENT
 # set log level to INFO | DEBUG - default set to INFO
 #$script:LOG_LEVEL=INFO
 
-# enable / disable DICOM (true|false)
-#$script:DICOM_ENABLE="false"
+# enable / disable DICOM (on|off)
+#$script:DICOM_ENABLE="off"
 
 ######## Software configuration - change at your own risk :-)
 # Database
@@ -135,6 +135,11 @@ switch ( "$ARCH" ) {
 		Write-Host "Unknown architecture: $ARCH. Exiting." -ForegroundColor Red
 		Read-Host; exit 1
 	}
+
+	# Workaround to force 32bit JAVA in order to have DICOM working
+	if ( $DICOM_ENABLE -eq "on" ) {
+		$script:JAVA_ARCH=32
+	}
 }
 
 ######## MySQL Software
@@ -161,7 +166,7 @@ $script:JAVA_DIR="jdk-11.0.11+9-jre"
 
 ######## JAVA 32bit
 # DICOM workaround - force JAVA_ARCH to 32 bit
-if ( $JAVA_ARCH -eq "32" -Or $DICOM_ENABLE -eq "true" ) {
+if ( $JAVA_ARCH -eq "32" ) {
 	# Setting JRE 32 bit
 	### JRE 8 32bit - openjdk distribution
 	# https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jre_x86-32_windows_hotspot_8u292b10.zip
@@ -262,11 +267,6 @@ function java_lib_setup {
 	switch ( "$JAVA_ARCH" ) {
 		"64" { $script:NATIVE_LIB_PATH="$OH_PATH\$OH_DIR\lib\native\Win64" }
 		"32" { $script:NATIVE_LIB_PATH="$OH_PATH\$OH_DIR\lib\native\Windows" }
-	}
-
-	# Dicom workaround - force 32bit libs
-	if ( $DICOM_ENABLE -eq "true" ) {
-		 $script:NATIVE_LIB_PATH="$OH_PATH\$OH_DIR\lib\native\Windows"
 	}
 
 	# CLASSPATH setup

--- a/poh-bundle-win/oh.ps1
+++ b/poh-bundle-win/oh.ps1
@@ -148,10 +148,6 @@ $script:MYSQL_DIR="mariadb-$script:MYSQL_VERSION-win$script:MYSQL_ARCH"
 $script:EXT="zip"
 
 ######## JAVA Software
-
-# Workaround to force 32bit JAVA in order to have DICOM working
-$script:JAVA_ARCH=32
-
 ######## JAVA 64bit - default architecture
 ### JRE 11 - zulu
 #$script:JAVA_DISTRO="zulu11.45.27-ca-jre11.0.10-win_i686"


### PR DESCRIPTION
- Distro update: we finally have separated packaging for windows 32 (i686) and windows 64 (x_86_64), this should be the final layout:

OpenHospital-v1.11.0-multiarch-client/
OpenHospital-v1.11.0-linux_i686-portable/
OpenHospital-v1.11.0-linux_x86_64-portable/
OpenHospital-v1.11.0-windows_i686-portable/
OpenHospital-v1.11.0-windows_x86_64-portable/

- Workaround in Makefile in order to disable DICOM in the 64 bit version, since it's not working at the moment
- The workaround now forces JAVA to 32bit in any case / architecture for Windows O.S.
UPDATE: The workaround now forces JAVA to 32 bit on 32bit distro (even if run on a 64bit arch) and on 64bit distro with DICOM enabled.