### PR TITLE
OP-347 Cumulative software version update for 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ MYSQL_URL := https://archive.mariadb.org/
 # software versions
 JRE_32_VER := zulu11.60.19-ca-fx-jre11.0.17
 JRE_64_VER := zulu11.60.19-ca-fx-jre11.0.17
-MYSQL_WIN32_VER := 10.5.13
+MYSQL_WIN32_VER := 10.6.5
 MYSQL_WIN64_VER := 10.6.11
 MYSQL_LINUX32_VER := 10.5.18
 MYSQL_LINUX64_VER := 10.6.11

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,12 @@ MYSQL_LINUX64 := mysql-linux64.tar.gz
 JAVA_URL := https://cdn.azul.com/zulu/bin/
 MYSQL_URL := https://downloads.mariadb.com/MariaDB/
 # software versions
-JAVA_VERSION32 := zulu11.60.19-ca-fx-jre11.0.17
-JAVA_VERSION64 := zulu11.60.19-ca-fx-jre11.0.17
-MYSQL_VERSION := 10.6.11
-MYSQL32_VERSION := 10.6.9
+JRE_32_VER := zulu11.60.19-ca-fx-jre11.0.17
+JRE_64_VER := zulu11.60.19-ca-fx-jre11.0.17
+MYSQL_WIN32_VER := 10.5.13
+MYSQL_WIN64_VER := 10.6.11
+MYSQL_LINUX32_VER := 10.5.18
+MYSQL_LINUX64_VER := 10.6.11
 
 .PHONY: clone-all clean clean-downloads dw-all dw-jre-all dw-mysql-all compile-all docs-all
 
@@ -227,20 +229,20 @@ dw-mysql-all: $(MYSQL_LINUX32) $(MYSQL_LINUX64) $(MYSQL_WIN32) $(MYSQL_WIN64)
 
 # Java
 $(JRE_LINUX32):
-	wget -q -nc $(JAVA_URL)/$(JAVA_VERSION32)-linux_i686.tar.gz -O $(JRE_LINUX32)
+	wget -q -nc $(JAVA_URL)/$(JRE_VER32)-linux_i686.tar.gz -O $(JRE_LINUX32)
 $(JRE_LINUX64):
-	wget -q -nc $(JAVA_URL)/$(JAVA_VERSION64)-linux_x64.tar.gz -O $(JRE_LINUX64)
+	wget -q -nc $(JAVA_URL)/$(JRE_VER64)-linux_x64.tar.gz -O $(JRE_LINUX64)
 $(JRE_WIN32):
-	wget -q -nc $(JAVA_URL)/$(JAVA_VERSION32)-win_i686.zip -O $(JRE_WIN32)
+	wget -q -nc $(JAVA_URL)/$(JRE_VER32)-win_i686.zip -O $(JRE_WIN32)
 $(JRE_WIN64):
-	wget -q -nc $(JAVA_URL)/$(JAVA_VERSION64)-win_x64.zip -O $(JRE_WIN64)
+	wget -q -nc $(JAVA_URL)/$(JRE_VER64)-win_x64.zip -O $(JRE_WIN64)
 
 # MySQL / MariaDB
 $(MYSQL_LINUX32):
-	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_VERSION)/bintar-linux-x86/mariadb-$(MYSQL_VERSION)-linux-i686.tar.gz -O $(MYSQL_LINUX32)
+	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_LINUX32_VER)/bintar-linux-x86/mariadb-$(MYSQL_LINUX32_VER)-linux-i686.tar.gz -O $(MYSQL_LINUX32)
 $(MYSQL_LINUX64):
-	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_VERSION)/bintar-linux-x86_64/mariadb-$(MYSQL_VERSION)-linux-x86_64.tar.gz -O $(MYSQL_LINUX64)
+	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_LINUX64_VER)/bintar-linux-x86_64/mariadb-$(MYSQL_LINUX64_VER)-linux-x86_64.tar.gz -O $(MYSQL_LINUX64)
 $(MYSQL_WIN32):
-	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL32_VERSION)/win32-packages/mariadb-$(MYSQL32_VERSION)-win32.zip -O $(MYSQL_WIN32)
+	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_WIN32_VER)/win32-packages/mariadb-$(MYSQL_WIN32_VER)-win32.zip -O $(MYSQL_WIN32)
 $(MYSQL_WIN64):
-	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_VERSION)/winx64-packages/mariadb-$(MYSQL_VERSION)-winx64.zip -O $(MYSQL_WIN64)
+	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_WIN64_VER)/winx64-packages/mariadb-$(MYSQL_WIN64_VER)-winx64.zip -O $(MYSQL_WIN64)

--- a/Makefile
+++ b/Makefile
@@ -229,13 +229,13 @@ dw-mysql-all: $(MYSQL_LINUX32) $(MYSQL_LINUX64) $(MYSQL_WIN32) $(MYSQL_WIN64)
 
 # Java
 $(JRE_LINUX32):
-	wget -q -nc $(JAVA_URL)/$(JRE_VER32)-linux_i686.tar.gz -O $(JRE_LINUX32)
+	wget -q -nc $(JAVA_URL)/$(JRE_32_VER)-linux_i686.tar.gz -O $(JRE_LINUX32)
 $(JRE_LINUX64):
-	wget -q -nc $(JAVA_URL)/$(JRE_VER64)-linux_x64.tar.gz -O $(JRE_LINUX64)
+	wget -q -nc $(JAVA_URL)/$(JRE_64_VER)-linux_x64.tar.gz -O $(JRE_LINUX64)
 $(JRE_WIN32):
-	wget -q -nc $(JAVA_URL)/$(JRE_VER32)-win_i686.zip -O $(JRE_WIN32)
+	wget -q -nc $(JAVA_URL)/$(JRE_32_VER)-win_i686.zip -O $(JRE_WIN32)
 $(JRE_WIN64):
-	wget -q -nc $(JAVA_URL)/$(JRE_VER64)-win_x64.zip -O $(JRE_WIN64)
+	wget -q -nc $(JAVA_URL)/$(JRE_64_VER)-win_x64.zip -O $(JRE_WIN64)
 
 # MySQL / MariaDB
 $(MYSQL_LINUX32):

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,6 @@ $(WIN64).zip: compile-all dw-all
 	cp *.pdf $(WIN64)/doc
 	# create package
 	# include 32bit JRE for DICOM
-	unzip $(JRE_WIN32) -d $(WIN64)
 	unzip $(JRE_WIN64) -d $(WIN64)
 	unzip $(MYSQL_WIN64) -d $(WIN64) -x "*/lib/*"
 	zip -r $(WIN64).zip $(WIN64)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ MYSQL_LINUX32 := mysql-linux32.tar.gz
 MYSQL_LINUX64 := mysql-linux64.tar.gz
 # download url
 JAVA_URL := https://cdn.azul.com/zulu/bin/
-MYSQL_URL := https://downloads.mariadb.com/MariaDB/
+#MYSQL_URL := https://downloads.mariadb.com/MariaDB/
+MYSQL_URL := https://archive.mariadb.org/
 # software versions
 JRE_32_VER := zulu11.60.19-ca-fx-jre11.0.17
 JRE_64_VER := zulu11.60.19-ca-fx-jre11.0.17
@@ -241,7 +242,7 @@ $(JRE_WIN64):
 $(MYSQL_LINUX32):
 	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_LINUX32_VER)/bintar-linux-x86/mariadb-$(MYSQL_LINUX32_VER)-linux-i686.tar.gz -O $(MYSQL_LINUX32)
 $(MYSQL_LINUX64):
-	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_LINUX64_VER)/bintar-linux-x86_64/mariadb-$(MYSQL_LINUX64_VER)-linux-x86_64.tar.gz -O $(MYSQL_LINUX64)
+	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_LINUX64_VER)/bintar-linux-systemd-x86_64/mariadb-$(MYSQL_LINUX64_VER)-linux-systemd-x86_64.tar.gz -O $(MYSQL_LINUX64)
 $(MYSQL_WIN32):
 	wget -q -nc $(MYSQL_URL)/mariadb-$(MYSQL_WIN32_VER)/win32-packages/mariadb-$(MYSQL_WIN32_VER)-win32.zip -O $(MYSQL_WIN32)
 $(MYSQL_WIN64):

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ MYSQL_LINUX64 := mysql-linux64.tar.gz
 JAVA_URL := https://cdn.azul.com/zulu/bin/
 MYSQL_URL := https://downloads.mariadb.com/MariaDB/
 # software versions
-JAVA_VERSION32 := zulu11.58.25-ca-jre11.0.16.1
-JAVA_VERSION64 := zulu11.58.23-ca-jre11.0.16.1
-MYSQL_VERSION := 10.2.44
-MYSQL32_VERSION := 10.2.41
+JAVA_VERSION32 := zulu11.60.19-ca-fx-jre11.0.17
+JAVA_VERSION64 := zulu11.60.19-ca-fx-jre11.0.17
+MYSQL_VERSION := 10.6.11
+MYSQL32_VERSION := 10.6.9
 
 .PHONY: clone-all clean clean-downloads dw-all dw-jre-all dw-mysql-all compile-all docs-all
 

--- a/oh-bundle/OH-README.md
+++ b/oh-bundle/OH-README.md
@@ -391,9 +391,9 @@ In order to download and unzip Java:
 - Visit  https://cdn.azul.com/zulu/bin/
 - download the **JRE - .zip version**
 
-**x86 - 32bit:** https://cdn.azul.com/zulu/bin/zulu11.58.25-ca-jre11.0.16.1-win_i686.zip
+**x86 - 32bit:** https://cdn.azul.com/zulu/bin/zulu11.60.19-ca-fx-jre11.0.17-win_i686.zip
 
-**x64 - 64bit:** https://cdn.azul.com/zulu/bin/zulu11.58.23-ca-jre11.0.16.1-win_x64.zip
+**x64 - 64bit:** https://cdn.azul.com/zulu/bin/zulu11.60.19-ca-fx-jre11.0.17-win_x64.zip
 
 - unzip the downloaded file into the base directory where OpenHospital has been placed.
 

--- a/oh-bundle/OH-README.md
+++ b/oh-bundle/OH-README.md
@@ -170,6 +170,7 @@ It's also possible to start Open Hospital with the legacy batch file (old oh.bat
 
 - **C**    start Open Hospital in CLIENT mode, usually when an external database server is used (Client / Server configuration)
 - **P**    start Open Hospital in PORTABLE mode, where data is saved locally
+- **S**    start Open Hospital in SERVER mode: the local portable instance of MariaDB is launched
 - **d**    start OH in DEBUG mode - useful to debug errors or bugs by logging more extended informations to log file
 - **D**    start OH with Demo data - loads a demo database in order to test the software 
 - **g**    generate OH configuration files (oh/rsc/\*.properties) and exit
@@ -259,9 +260,9 @@ If a database server hostname/address is specified (other then localhost), OH ca
 ```
 ############## OH local configuration - change at your own risk :-) ##############
 # Database
-MYSQL_SERVER=localhost
-MYSQL_PORT=3306
-MYSQL_ROOT_PW="xxxxxxxxxx"
+DATABASE_SERVER=localhost
+DATABASE_PORT=3306
+DATABASE_ROOT_PW="xxxxxxxxxx"
 DATABASE_NAME=oh
 DATABASE_USER=isf
 DATABASE_PASSWORD="xxxxx"
@@ -319,7 +320,7 @@ data/dicom_storage
 External software package downloaded at first run:
 
 ```
-Mariadb 10.2.x server
+Mariadb 10.x.x server
 Java JRE, Zulu or OpenJDK distribution
 ```
 
@@ -398,16 +399,16 @@ In order to download and unzip Java:
 
 In order to download and unzip mariadb:
 
-- Visit https://downloads.mariadb.org/mariadb/10.2/
+- Visit https://mariadb.org/download/
 - Select the Operating System: **Windows**
 - Select package type: **ZIP file**
 - Select CPU (architecture) **32 / 64**
 - Download the zip file:
 
 
-**x86 - 32bit:** https://downloads.mariadb.com/MariaDB/mariadb-10.2.41/win32-packages/mariadb-10.2.41-win32.zip
+**x86 - 32bit:** https://archive.mariadb.org/mariadb-10.6.5/win32-packages/mariadb-10.6.5-win32.zip
 
-**x64 - 64bit:** https://downloads.mariadb.com/MariaDB/mariadb-10.2.44/winx64-packages/mariadb-10.2.44-winx64.zip
+**x64 - 64bit:** https://archive.mariadb.org/mariadb-10.6.11/winx64-packages/mariadb-10.6.11-winx64.zip
 
 - unzip the downloaded file into the base directory where OpenHospital has been placed.
 
@@ -424,6 +425,10 @@ A short description of changes for the Linux version (mostly the same behavior a
 - **Unified script** for:
     Portable 64bit (default) and 32bit (with automatic architecture detection)
     Open Hospital client (no more separated startup.sh is needed ;-) (**it is now possible to package every linux distro, client/portable/32 or 64 bit with a single package**)
+- **New**: SERVER mode support
+- **New**: Arabic Language support **oh.sh -l ar**
+- **New**: Full 64bit support on Windows, also for DICOM !
+-
 - **New**: Language support (both via variable in the script or user input option: **oh.sh -l fr**)
 - **New**: Demo database support (See oh.sh -D)
 - **New**: Client mode support (see oh.sh -C)
@@ -445,11 +450,11 @@ A short description of changes for the Linux version (mostly the same behavior a
 - Added sql subdirectory to organize sql creation scripts
 - Added various checks about correct settings of parameters and startup of services
 - Added security controls (no more _rm -rf_ here and there :-)
-- Added support for **MariaDB** - (tested with version up to mariadb-10.2) (OH seems faster and more responsive)
+- Added support for **MariaDB** for better security and performance
 - Windows -> addedd support for path with spaces / special characters 
 - Updated MySQL db and user creation syntax (now compatible with MySQL 8 - unsupported)
 - Fixed _a_few_ bugs ;-)
 
 
-*last updated: 2022.03.03*
+*last updated: 2022.11.22*
 

--- a/oh-bundle/data/conf/my.cnf.dist
+++ b/oh-bundle/data/conf/my.cnf.dist
@@ -1,10 +1,10 @@
 [client]
-port = MYSQL_PORT
+port = DATABASE_PORT
 socket = "OH_PATH_SUBSTITUTE/TMP_DIR/mysql.sock"  
 
 [mysqld] 
-port = MYSQL_PORT 
-bind-address = MYSQL_SERVER
+port = DATABASE_PORT 
+bind-address = DATABASE_SERVER
 socket = "OH_PATH_SUBSTITUTE/TMP_DIR/mysql.sock"
 pid-file = "OH_PATH_SUBSTITUTE/TMP_DIR/mysql.pid"
 basedir = "OH_PATH_SUBSTITUTE/MYSQL_DISTRO"  


### PR DESCRIPTION
Batch of updates to software versions (JRE and MariaDB).
Separated 32bit architectures and cleaned up exceptions needed for DICOM support
See https://github.com/informatici/openhospital-gui/pull/1485 for details
