### PR TITLE
OP-292 Create pre-release in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
  
     - name: Delete last dev release
       if: startsWith(github.ref, 'refs/tags/develop')
-      uses: dev-drprasad/delete-older-releases@v0.2
+      uses: dev-drprasad/delete-older-releases@v0.2.1
       with:
         delete_tag_pattern: develop
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/develop')
       uses: dev-drprasad/delete-older-releases@v0.2.1
       with:
+        repo: informatici/openhospital
+        keep_latest: 0
         delete_tag_pattern: develop
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Create draft release
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         draft: true
         files: |
@@ -66,7 +66,7 @@ jobs:
               
     - name: Create dev release
       if: startsWith(github.ref, 'refs/tags/develop')
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         name: Develop Release ${{ steps.date.outputs.date }}
         prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Create draft release
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@v1
       with:
         draft: true
         files: |
@@ -66,7 +66,7 @@ jobs:
               
     - name: Create dev release
       if: startsWith(github.ref, 'refs/tags/develop')
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@v1
       with:
         name: Develop Release ${{ steps.date.outputs.date }}
         prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         
     - name: Rename artifact
       if: startsWith(github.ref, 'refs/tags/develop')
-      run: mv OpenHospital-develop-multiarch-client.zip OpenHospital-develop-multiarch-${{ steps.date.outputs.date }}.zip 
+      run: mv OpenHospital-develop-multiarch-client.zip OpenHospital-dev${{ steps.date.outputs.date }}-multiarch-client.zip 
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         name: Develop Release ${{ steps.date.outputs.date }}
         prerelease: true
         files: |
-          OpenHospital-develop-multiarch-${{ steps.date.outputs.date }}.zip
+          OpenHospital-dev${{ steps.date.outputs.date }}-multiarch-client.zip
           # OpenHospital-*.tar.gz 
           # OpenHospital-*.zip
         body: Development pre-release for testers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,15 @@ jobs:
         body_path: RELEASE_NOTES.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Create dev release
+      if: startsWith(github.ref, 'refs/tags/develop')
+      uses: softprops/action-gh-release@v1
+      with:
+        prerelease: true
+        files: |
+          OpenHospital-*.tar.gz 
+          OpenHospital-*.zip
+        body_path: RELEASE_NOTES.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/develop')
       uses: softprops/action-gh-release@v1
       with:
+        name: Develop Release
         prerelease: true
         files: |
           OpenHospital-*.tar.gz 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - '**.md'
     tags:
       - 'v*'
+      - 'develop*'      
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,34 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y%m%d')"
+        
+    - name: Rename artifact
+      if: startsWith(github.ref, 'refs/tags/develop')
+      run: mv OpenHospital-develop-multiarch-client.zip OpenHospital-develop-multiarch-${{ steps.date.outputs.date }}.zip 
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ 
+    - name: Delete last dev release
+      if: startsWith(github.ref, 'refs/tags/develop')
+      uses: dev-drprasad/delete-older-releases@v0.2
+      with:
+        delete_tag_pattern: develop
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              
     - name: Create dev release
       if: startsWith(github.ref, 'refs/tags/develop')
       uses: softprops/action-gh-release@v1
       with:
-        name: Develop Release
+        name: Develop Release ${{ steps.date.outputs.date }}
         prerelease: true
         files: |
-          OpenHospital-*.tar.gz 
-          OpenHospital-*.zip
-        body_path: RELEASE_NOTES.md
+          OpenHospital-develop-multiarch-${{ steps.date.outputs.date }}.zip
+          # OpenHospital-*.tar.gz 
+          # OpenHospital-*.zip
+        body: Development pre-release for testers
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adapt the workflow to create a pre-release upon "develop" tag

Notes:

- [x] we can publish only multiarch instead of all `.tar.gz` and `.zip` files
- [x] we can add a step with dev-drprasad/delete-older-releases@v0.2 in order to delete previous "develop" tag and create a new one (so the release date is updated)
- [x] we can add a timestamp in both release and file name 
